### PR TITLE
updates README to link to `dekn-cli-python`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a GitHub Action to deploy a Dash application to Dash Enterprise 5.
 
+Under the hood, it uses https://github.com/plotly/dekn-cli-python :rocket:
+
 ## Usage
 
 To use a GitHub action you can just reference it on your Workflow file


### PR DESCRIPTION
See title...

I initially thought this was using `dekn-cli`! Let's make it clear that it uses `dekn-cli-python`!