### PR TITLE
Update link for Git workflows documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Under the hood, it uses `de-client` :rocket:
 ## Usage
 
 To use a GitHub action you can just reference it on your Workflow file
-(for more info check [this article by Github](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow))
+(for more info check [this article by Github](https://docs.github.com/en/actions/writing-workflows/quickstart))
 
 If you have your application code on Github, add and commit the following to `<your-app>/.github/workflows/deploy.yml` to get started. Make sure to set the required variables in the "Secrets and variables" for Actions in your repository settings.
 


### PR DESCRIPTION
I changed the link in the Readme to https://docs.github.com/en/actions/writing-workflows/quickstart. I think this link is a good place to start reading more about Git workflows.